### PR TITLE
Added an ImageZoom view for zooming in on coin images

### DIFF
--- a/app/src/main/java/info/noahortega/bluecointracker/BCDetail/DetailFragment.kt
+++ b/app/src/main/java/info/noahortega/bluecointracker/BCDetail/DetailFragment.kt
@@ -8,12 +8,16 @@ import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import info.noahortega.bluecointracker.R
 
 import info.noahortega.bluecointracker.SharedViewModel
 import info.noahortega.bluecointracker.database.BlueCoin
 import info.noahortega.bluecointracker.databinding.FragmentDetailBinding
+import kotlinx.android.synthetic.main.activity_main.*
 
 
 class DetailFragment : Fragment() {
@@ -30,7 +34,6 @@ class DetailFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentDetailBinding.inflate(inflater, container, false)
-
         return binding.root
     }
 
@@ -43,9 +46,11 @@ class DetailFragment : Fragment() {
             resources.getIdentifier(coin.shortTitle, "string", context?.packageName)
         )
 
-        binding.topMedia.setImageResource(
-            resources.getIdentifier(coin.imageAddress, "drawable", requireContext().packageName)
-        )
+
+        val imageID:Int = resources.getIdentifier(coin.imageAddress, "drawable", requireContext().packageName)
+        binding.topMedia.setImageResource(imageID)
+
+        binding.topMedia.setOnClickListener { model.navToImageZoom(findNavController(), imageID) }
 
 
         val text: String = getString(resources.getIdentifier(coin.description,"string", requireContext().packageName))
@@ -57,9 +62,6 @@ class DetailFragment : Fragment() {
             val styledText: Spanned = Html.fromHtml(text, FROM_HTML_MODE_LEGACY)
             binding.descriptionText.text = styledText
         }
-
-
-
 
         binding.checkBox.isChecked = coin.checked
 

--- a/app/src/main/java/info/noahortega/bluecointracker/BCDetail/ImageZoom.kt
+++ b/app/src/main/java/info/noahortega/bluecointracker/BCDetail/ImageZoom.kt
@@ -1,0 +1,239 @@
+package info.noahortega.bluecointracker.BCDetail
+
+import android.content.Context
+import android.graphics.Matrix
+import android.graphics.PointF
+import android.util.AttributeSet
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.ScaleGestureDetector
+import android.view.View
+import androidx.annotation.Nullable
+import androidx.appcompat.widget.AppCompatImageView
+
+//Credit to David Sunday
+//https://medium.com/@daveson/android-imageview-double-tap-and-pinch-zoom-with-multi-touch-gestures-in-kotlin-1559a5dd4a69
+class ImageZoom : AppCompatImageView, View.OnTouchListener,
+    GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener {
+    //shared constructing
+    private var mContext: Context? = null
+    private var mScaleDetector: ScaleGestureDetector? = null
+    private var mGestureDetector: GestureDetector? = null
+    var mMatrix: Matrix? = null
+    private var mMatrixValues: FloatArray? = null
+    var mode = NONE
+
+    // Scales
+    var mSaveScale = 1f
+    var mMinScale = 1f
+    var mMaxScale = 20f
+
+    // view dimensions
+    var origWidth = 0f
+    var origHeight = 0f
+    var viewWidth = 0
+    var viewHeight = 0
+    private var mLast = PointF()
+    private var mStart = PointF()
+
+    constructor(context: Context) : super(context) {
+        sharedConstructing(context)
+    }
+
+    constructor(context: Context, @Nullable attrs: AttributeSet?) : super(context, attrs) {
+        sharedConstructing(context)
+    }
+
+    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context!!, attrs, defStyleAttr)
+
+    private fun sharedConstructing(context: Context) {
+        super.setClickable(true)
+        mContext = context
+        mScaleDetector = ScaleGestureDetector(context, ScaleListener())
+        mMatrix = Matrix()
+        mMatrixValues = FloatArray(9)
+        imageMatrix = mMatrix
+        scaleType = ScaleType.MATRIX
+        mGestureDetector = GestureDetector(context, this)
+        setOnTouchListener(this)
+    }
+
+    private inner class ScaleListener : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+        override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
+            mode = ZOOM
+            return true
+        }
+
+        override fun onScale(detector: ScaleGestureDetector): Boolean {
+            var mScaleFactor = detector.scaleFactor
+            val prevScale = mSaveScale
+            mSaveScale *= mScaleFactor
+            if (mSaveScale > mMaxScale) {
+                mSaveScale = mMaxScale
+                mScaleFactor = mMaxScale / prevScale
+            } else if (mSaveScale < mMinScale) {
+                mSaveScale = mMinScale
+                mScaleFactor = mMinScale / prevScale
+            }
+            if (origWidth * mSaveScale <= viewWidth
+                || origHeight * mSaveScale <= viewHeight) {
+                mMatrix!!.postScale(mScaleFactor, mScaleFactor, viewWidth / 2.toFloat(),
+                    viewHeight / 2.toFloat())
+            } else {
+                mMatrix!!.postScale(mScaleFactor, mScaleFactor,
+                    detector.focusX, detector.focusY)
+            }
+            fixTranslation()
+            return true
+        }
+    }
+
+    private fun fitToScreen() {
+        mSaveScale = 1f
+        val scale: Float
+        val drawable = drawable
+        if (drawable == null || drawable.intrinsicWidth == 0 || drawable.intrinsicHeight == 0) return
+        val imageWidth = drawable.intrinsicWidth
+        val imageHeight = drawable.intrinsicHeight
+        val scaleX = viewWidth.toFloat() / imageWidth.toFloat()
+        val scaleY = viewHeight.toFloat() / imageHeight.toFloat()
+        scale = scaleX.coerceAtMost(scaleY)
+        mMatrix!!.setScale(scale, scale)
+
+        // Center the image
+        var redundantYSpace = (viewHeight.toFloat()
+                - scale * imageHeight.toFloat())
+        var redundantXSpace = (viewWidth.toFloat()
+                - scale * imageWidth.toFloat())
+        redundantYSpace /= 2.toFloat()
+        redundantXSpace /= 2.toFloat()
+        mMatrix!!.postTranslate(redundantXSpace, redundantYSpace)
+        origWidth = viewWidth - 2 * redundantXSpace
+        origHeight = viewHeight - 2 * redundantYSpace
+        imageMatrix = mMatrix
+    }
+
+    fun fixTranslation() {
+        mMatrix!!.getValues(mMatrixValues) //put matrix values into a float array so we can analyze
+        val transX = mMatrixValues!![Matrix.MTRANS_X] //get the most recent translation in x direction
+        val transY = mMatrixValues!![Matrix.MTRANS_Y] //get the most recent translation in y direction
+        val fixTransX = getFixTranslation(transX, viewWidth.toFloat(), origWidth * mSaveScale)
+        val fixTransY = getFixTranslation(transY, viewHeight.toFloat(), origHeight * mSaveScale)
+        if (fixTransX != 0f || fixTransY != 0f) mMatrix!!.postTranslate(fixTransX, fixTransY)
+    }
+
+    private fun getFixTranslation(trans: Float, viewSize: Float, contentSize: Float): Float {
+        val minTrans: Float
+        val maxTrans: Float
+        if (contentSize <= viewSize) { // case: NOT ZOOMED
+            minTrans = 0f
+            maxTrans = viewSize - contentSize
+        } else { //CASE: ZOOMED
+            minTrans = viewSize - contentSize
+            maxTrans = 0f
+        }
+        if (trans < minTrans) { // negative x or y translation (down or to the right)
+            return -trans + minTrans
+        }
+        if (trans > maxTrans) { // positive x or y translation (up or to the left)
+            return -trans + maxTrans
+        }
+        return 0F
+    }
+
+    private fun getFixDragTrans(delta: Float, viewSize: Float, contentSize: Float): Float {
+        return if (contentSize <= viewSize) {
+            0F
+        } else delta
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        viewWidth = MeasureSpec.getSize(widthMeasureSpec)
+        viewHeight = MeasureSpec.getSize(heightMeasureSpec)
+        if (mSaveScale == 1f) {
+
+            // Fit to screen.
+            fitToScreen()
+        }
+    }
+
+    /*
+        Ontouch
+    */
+    override fun onTouch(view: View?, event: MotionEvent): Boolean {
+        mScaleDetector!!.onTouchEvent(event)
+        mGestureDetector!!.onTouchEvent(event)
+        val currentPoint = PointF(event.x, event.y)
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> {
+                mLast.set(currentPoint)
+                mStart.set(mLast)
+                mode = DRAG
+            }
+            MotionEvent.ACTION_MOVE -> if (mode == DRAG) {
+                val dx = currentPoint.x - mLast.x
+                val dy = currentPoint.y - mLast.y
+                val fixTransX = getFixDragTrans(dx, viewWidth.toFloat(), origWidth * mSaveScale)
+                val fixTransY = getFixDragTrans(dy, viewHeight.toFloat(), origHeight * mSaveScale)
+                mMatrix!!.postTranslate(fixTransX, fixTransY)
+                fixTranslation()
+                mLast[currentPoint.x] = currentPoint.y
+            }
+            MotionEvent.ACTION_POINTER_UP -> mode = NONE
+        }
+        imageMatrix = mMatrix
+        return false
+    }
+
+    /*
+        GestureListener
+     */
+    override fun onDown(motionEvent: MotionEvent): Boolean {
+        return false
+    }
+
+    override fun onShowPress(motionEvent: MotionEvent) {}
+    override fun onSingleTapUp(motionEvent: MotionEvent): Boolean {
+        return false
+    }
+
+    override fun onScroll(motionEvent: MotionEvent, motionEvent1: MotionEvent, v: Float, v1: Float): Boolean {
+        return false
+    }
+
+    override fun onLongPress(motionEvent: MotionEvent) {}
+    override fun onFling(motionEvent: MotionEvent, motionEvent1: MotionEvent, v: Float, v1: Float): Boolean {
+        return false
+    }
+
+    /*
+        onDoubleTap
+     */
+    override fun onSingleTapConfirmed(motionEvent: MotionEvent): Boolean {
+        return false
+    }
+
+
+    override fun onDoubleTap(event: MotionEvent): Boolean {
+        if(mSaveScale == 1f) {
+            //TODO:zoom on double click
+        }
+        else {
+            fitToScreen()
+        }
+        return false
+    }
+
+    override fun onDoubleTapEvent(motionEvent: MotionEvent): Boolean {
+        return false
+    }
+
+    companion object {
+
+        // Image States
+        const val NONE = 0
+        const val DRAG = 1
+        const val ZOOM = 2
+    }
+}

--- a/app/src/main/java/info/noahortega/bluecointracker/BCDetail/ImageZoomFragment.kt
+++ b/app/src/main/java/info/noahortega/bluecointracker/BCDetail/ImageZoomFragment.kt
@@ -1,0 +1,35 @@
+package info.noahortega.bluecointracker.BCDetail
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
+import info.noahortega.bluecointracker.R
+import info.noahortega.bluecointracker.SharedViewModel
+import kotlinx.android.synthetic.main.fragment_image_zoom.*
+
+
+class ImageZoomFragment : Fragment() {
+
+    private val model: SharedViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_image_zoom, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        zoomImage.setImageResource(model.imageID)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+    }
+
+}

--- a/app/src/main/java/info/noahortega/bluecointracker/SharedViewModel.kt
+++ b/app/src/main/java/info/noahortega/bluecointracker/SharedViewModel.kt
@@ -26,9 +26,16 @@ class SharedViewModel(app: Application) : AndroidViewModel(app) {
     private val uiScope = CoroutineScope(Dispatchers.Main + uiJob)
 
     val levelIDToNamesMap = mapOf(
-        1 to app.getString(R.string.delfino_plaza), 2 to app.getString(R.string.bianco_hills), 3 to app.getString(R.string.ricco_harbor),
-        4 to app.getString(R.string.gelato_beach), 5 to app.getString(R.string.noki_bay), 6 to app.getString(R.string.pinna_park),
-        7 to app.getString(R.string.sirena_beach), 8 to app.getString(R.string.pianta_village), 9 to app.getString(R.string.corona_mountain))
+        1 to app.getString(R.string.delfino_plaza),
+        2 to app.getString(R.string.bianco_hills),
+        3 to app.getString(R.string.ricco_harbor),
+        4 to app.getString(R.string.gelato_beach),
+        5 to app.getString(R.string.noki_bay),
+        6 to app.getString(R.string.pinna_park),
+        7 to app.getString(R.string.sirena_beach),
+        8 to app.getString(R.string.pianta_village),
+        9 to app.getString(R.string.corona_mountain)
+    )
 
     val liveLevels: LiveData<List<Level>> = database.getLiveOrderedLevels()
 
@@ -39,7 +46,7 @@ class SharedViewModel(app: Application) : AndroidViewModel(app) {
             database.updateBlueCoin(coin)
             updateLevelCompletion(coin.myLevelId)
 
-            if(updateList) {
+            if (updateList) {
                 queriedCoins = database.getCoinsByLevelId(queriedCoins!![0].myLevelId)
             }
         }
@@ -47,9 +54,10 @@ class SharedViewModel(app: Application) : AndroidViewModel(app) {
 
     var curLevelId = -1
     private var queriedCoins: List<BlueCoin>? = null
-    fun getQueriedCoins() : List<BlueCoin>? { //getter
+    fun getQueriedCoins(): List<BlueCoin>? { //getter
         return queriedCoins
     }
+
     fun navToListWithLevel(navCon: NavController, levelId: Int) {
         ioScope.launch {
             curLevelId = levelId
@@ -59,13 +67,15 @@ class SharedViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     private var detailViewCoin: BlueCoin? = null
-    fun getSelectedCoin() : BlueCoin? { //getter
+    fun getSelectedCoin(): BlueCoin? { //getter
         return detailViewCoin
     }
+
     private var coinLevel: Level? = null
-    fun getSelectedCoinLevel() : Level? { //getter
+    fun getSelectedCoinLevel(): Level? { //getter
         return coinLevel
     }
+
     fun navToDetailWithCoin(navCon: NavController, coinId: Long) {
         ioScope.launch {
             detailViewCoin = database.getCoinById(coinId)
@@ -90,7 +100,11 @@ class SharedViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-
+    var imageID = -1
+    fun navToImageZoom(navCon: NavController, resourceID: Int) {
+        imageID = resourceID
+        navCon.navigate(R.id.action_detailFragment_to_imageZoomFragment)
+    }
 
 
     /*public fun initDatabase() {

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -14,9 +14,10 @@
         <ImageView
             android:id="@+id/top_media"
             android:layout_width="match_parent"
-            android:layout_height="150dp"
+            android:layout_height="0dp"
             android:background="@android:color/background_dark"
             android:contentDescription="@string/default_coin_image_description"
+            app:layout_constraintDimensionRatio="2.74"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_image_zoom.xml
+++ b/app/src/main/res/layout/fragment_image_zoom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <info.noahortega.bluecointracker.BCDetail.ImageZoom
+        android:background="@android:color/background_dark"
+        android:id="@+id/zoomImage"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:src="@drawable/coin_bh_01"/>
+
+</FrameLayout>

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -29,5 +29,14 @@
         android:id="@+id/detailFragment"
         android:name="info.noahortega.bluecointracker.BCDetail.DetailFragment"
         android:label="fragment_detail"
-        tools:layout="@layout/fragment_detail" />
+        tools:layout="@layout/fragment_detail" >
+        <action
+            android:id="@+id/action_detailFragment_to_imageZoomFragment"
+            app:destination="@id/imageZoomFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/imageZoomFragment"
+        android:name="info.noahortega.bluecointracker.BCDetail.ImageZoomFragment"
+        android:label="fragment_image_zoom"
+        tools:layout="@layout/fragment_image_zoom" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <string name="home_total_percentage_done">You are %1$d\%% to completion</string>
     <string name="youtube_link">Youtube Clip</string>
     <string name="coin_conditions_header">Collection Conditions</string>
-    <string name="coin_description_header" >Description</string>
+    <string name="coin_description_header">Description</string>
     <string name="text_not_found">N/A</string>
     <string name="default_coin_image_description">Default Image. There is not a custom image for this coin</string>
     <string name="youtube_image_description">Youtube logo</string>


### PR DESCRIPTION
-added a fragment containing only a custom ImageZoom view for zooming in on coin images (resolves #9)
-changed the detail view top media to transition to the zoom fragment when clicked
-changed detail view top media from fixed height to ratio dimensions